### PR TITLE
Remove distance rounding

### DIFF
--- a/cvrplib/download/download_instance.py
+++ b/cvrplib/download/download_instance.py
@@ -8,7 +8,7 @@ from .download_utils import find_set, is_vrptw
 
 
 @lru_cache()
-def download_instance(name: str, distance_rounding=None):
+def download_instance(name: str):
     """
     Downloads an instance from CVRPLIB.
 
@@ -25,4 +25,4 @@ def download_instance(name: str, distance_rounding=None):
     response = urlopen(CVRPLIB_URL + f"{find_set(name)}/{name}.{ext}")
 
     parser = parse_solomon if is_vrptw(name) else parse_vrplib
-    return parser(response.read().decode("utf-8"), distance_rounding)
+    return parser(response.read().decode("utf-8"))

--- a/cvrplib/parse/parse_distances.py
+++ b/cvrplib/parse/parse_distances.py
@@ -6,7 +6,7 @@ import numpy as np
 Instance = Dict[str, Any]
 
 
-def parse_distances(instance: Instance) -> Dict[str, np.ndarray]:
+def parse_distances(instance: Instance) -> np.ndarray:
     """
     Parses the distances. The specification "edge_weight_type" describes how
     the distances should be parsed. The two main ways are to calculate the
@@ -17,49 +17,43 @@ def parse_distances(instance: Instance) -> Dict[str, np.ndarray]:
     ----------
     instance
         The (partially) parsed instance. We assume that all VRPLIB
-        specifications and data are already stored in `instance`.
+        specifications and data are already contained in ``instance``.
 
     Returns
     -------
-    An n-by-n distances matrix.
+    np.ndarray
+        An n-by-n distances matrix.
     """
-    edge_weight_type = instance["edge_weight_type"]
+    edge_type = instance["edge_weight_type"]
 
-    if "2D" in edge_weight_type:  # Euclidean distance on node coordinates
-        dists = pairwise_euclidean(instance["node_coord"])
+    if "2D" in edge_type:  # Euclidean distance on node coordinates
+        distance = pairwise_euclidean(instance["node_coord"])
 
-        if edge_weight_type == "EUC_2D":
-            dists = np.round(dists)
-        elif edge_weight_type == "FLOOR_2D":
-            dists = np.floor(dists)
-        elif edge_weight_type == "EXACT_2D":
-            pass
-        else:
-            raise ValueError(f"Edge weight type {edge_weight_type} unknown.")
+        if edge_type == "EUC_2D":
+            return np.round(distance)
 
-        return {"distance": dists}
+        if edge_type == "FLOOR_2D":
+            return np.floor(distance)
 
-    if edge_weight_type == "EXPLICIT":
-        edge_weight_format = instance["edge_weight_format"]
-        edge_weight = instance["edge_weight"]
+        if edge_type == "EXACT_2D":
+            return distance
+
+    if edge_type == "EXPLICIT":
+        fmt = instance["edge_weight_format"]
+        weights = instance["edge_weight"]
         dimension = instance["dimension"]
 
-        if edge_weight_format == "LOWER_ROW":
-            lr_repr = get_representation(instance["edge_weight"], n=dimension)
-
-            if lr_repr == "flattened":
-                return {"distance": from_flattened(edge_weight, n=dimension)}
-            elif lr_repr == "triangular":
-                return {"distance": from_triangular(edge_weight)}
+        if fmt == "LOWER_ROW":
+            # The Eilon instances with are not correctly specified.
+            if "Eilon" in instance["comment"].lower():
+                return from_eilon(weights, n=dimension)
             else:
-                raise ValueError(f"Lower row represention {lr_repr} unkown.")
+                return from_lower_row(weights)
 
-        if edge_weight_format == "FULL_MATRIX":
-            return {"distance": np.array(instance["edge_weight"])}
+        if fmt == "FULL_MATRIX":
+            return np.array(instance["edge_weight"])
 
-        raise ValueError(f"Edge weight format {edge_weight_format} unknown.")
-
-    raise ValueError(f"Edge weight type {edge_weight_type} unknown.")
+    raise ValueError("Edge weight type or format unknown.")
 
 
 def pairwise_euclidean(coords: np.ndarray) -> np.ndarray:
@@ -86,30 +80,10 @@ def pairwise_euclidean(coords: np.ndarray) -> np.ndarray:
     return distances
 
 
-def get_representation(edge_weights: np.ndarray, n: int) -> str:
+def from_lower_row(triangular: np.ndarray) -> np.ndarray:
     """
-    Returns the representation type in which the lower row data is given.
-    This assumes that the instance has an explicit edge weight representation.
-    In such a case, some instances have a flattened representation (e.g.,
-    E-n13-k4), whereas others have a triangular one (e.g., ORTEC-n242-k12).
-
-
-    Parameters
-    ----------
-    edge_weights
-        The edge weights data.
-    n
-        The instance dimension.
-    """
-    if len(edge_weights) == n - 1:
-        return "triangular"
-    else:
-        return "flattened"
-
-
-def from_triangular(triangular: np.ndarray) -> np.ndarray:
-    """
-    Computes a full distances matrix from a triangular matrix.
+    Computes a full distances matrix from a lower row triangular matrix.
+    The triangular matrix does not contain the diagonal.
     """
     n = len(triangular) + 1
     distances = np.zeros((n, n))
@@ -122,17 +96,18 @@ def from_triangular(triangular: np.ndarray) -> np.ndarray:
     return distances
 
 
-def from_flattened(edge_weights: np.ndarray, n: int) -> np.ndarray:
+def from_eilon(edge_weights: np.ndarray, n: int) -> np.ndarray:
     """
-    Computes a full distances matrix from a flattened lower row representation.
+    Computes a full distances matrix from the Eilon instances with "LOWER_ROW"
+    edge weight format. The specification is incorrect, instead the edge weight
+    section needs to be parsed as a flattend, column-wise matrix.
 
-    The numbers in a flattened list correspond the matrix element indices
-    (1, 0), (2, 0), (2, 1), (3, 0), (3, 1), (3, 2), (4, 0), ...
+    See https://github.com/leonlan/CVRPLIB/issues/40.
     """
     distances = np.zeros((n, n))
 
     flattened = [dist for row in edge_weights for dist in row]
-    indices = sorted([(i, j) for (j, i) in combinations(range(n), r=2)])
+    indices = sorted([(i, j) for (i, j) in combinations(range(n), r=2)])
 
     for idx, (i, j) in enumerate(indices):
         d_ij = flattened[idx]

--- a/cvrplib/parse/parse_distances.py
+++ b/cvrplib/parse/parse_distances.py
@@ -13,14 +13,20 @@ def parse_distances(instance: Instance) -> Dict[str, np.ndarray]:
     Euclidean distances using the the node coordinates or by parsing an
     explicit distance matrix.
 
+    Parameters
+    ----------
     instance
-        The instance parsed so far. We assume that all VRPLIB specifications
-        and data sections are already inside `instance`.
+        The (partially) parsed instance. We assume that all VRPLIB
+        specifications and data are already stored in `instance`.
+
+    Returns
+    -------
+    An n-by-n distances matrix.
     """
     edge_weight_type = instance["edge_weight_type"]
 
     if "2D" in edge_weight_type:  # Euclidean distance on node coordinates
-        dists = euclidean(instance["node_coord"])
+        dists = pairwise_euclidean(instance["node_coord"])
 
         if edge_weight_type == "EUC_2D":
             dists = np.round(dists)
@@ -56,16 +62,18 @@ def parse_distances(instance: Instance) -> Dict[str, np.ndarray]:
     raise ValueError(f"Edge weight type {edge_weight_type} unknown.")
 
 
-def _identity(num):
-    return num
-
-
-def euclidean(coords: np.ndarray) -> np.ndarray:
+def pairwise_euclidean(coords: np.ndarray) -> np.ndarray:
     """
     Computes the pairwise Euclidean distances using the passed-in coordinates.
 
+    Parameters
+    ----------
     coords
         An n-by-2 array of location coordinates.
+
+    Returns
+    -------
+    An n-by-n distance matrix.
     """
     n = len(coords)
     distances = np.zeros((n, n))

--- a/cvrplib/parse/parse_solomon.py
+++ b/cvrplib/parse/parse_solomon.py
@@ -34,6 +34,6 @@ def parse_solomon(text: str) -> Instance:
     instance["demand"] = data[:, 3]
     instance["time_window"] = data[:, 4:6]
     instance["service_time"] = data[:, 6]
-    instance["distance"] = pairwise_euclidean(instance["node_coord"])
+    instance["edge_weight"] = pairwise_euclidean(instance["node_coord"])
 
     return instance

--- a/cvrplib/parse/parse_solomon.py
+++ b/cvrplib/parse/parse_solomon.py
@@ -2,7 +2,7 @@ from typing import Dict, Union
 
 import numpy as np
 
-from .parse_distances import euclidean
+from .parse_distances import pairwise_euclidean
 from .parse_utils import text2lines
 
 Instance = Dict[str, Union[str, int, float, np.ndarray]]
@@ -16,6 +16,10 @@ def parse_solomon(text: str) -> Instance:
     ----------
     text
         The instance text.
+
+    Returns
+    -------
+    The instance data as dictionary.
     """
     lines = text2lines(text)
 
@@ -30,6 +34,6 @@ def parse_solomon(text: str) -> Instance:
     instance["demand"] = data[:, 3]
     instance["time_window"] = data[:, 4:6]
     instance["service_time"] = data[:, 6]
-    instance["distance"] = euclidean(instance["node_coord"])
+    instance["distance"] = pairwise_euclidean(instance["node_coord"])
 
     return instance

--- a/cvrplib/parse/parse_solomon.py
+++ b/cvrplib/parse/parse_solomon.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Optional, Union, no_type_check
+from typing import Dict, Union
 
 import numpy as np
 
@@ -8,10 +8,7 @@ from .parse_utils import text2lines
 Instance = Dict[str, Union[str, int, float, np.ndarray]]
 
 
-@no_type_check  # typing bug in mypy, see below
-def parse_solomon(
-    text: str, distance_rounding: Optional[Callable] = None
-) -> Instance:
+def parse_solomon(text: str) -> Instance:
     """
     Parses the text of a Solomon VRPTW instance.
 
@@ -19,9 +16,6 @@ def parse_solomon(
     ----------
     text
         The instance text.
-    distance_rounding
-        A custom distance rounding function. The default is to follow the
-        VRPLIB convention, see ... # TODO
     """
     lines = text2lines(text)
 
@@ -36,15 +30,6 @@ def parse_solomon(
     instance["demand"] = data[:, 3]
     instance["time_window"] = data[:, 4:6]
     instance["service_time"] = data[:, 6]
-
-    # Bug in mypy: https://github.com/python/mypy/issues/4134
-    instance["distance"] = euclidean(
-        instance["node_coord"],
-        distance_rounding if distance_rounding is not None else _identity,
-    )
+    instance["distance"] = euclidean(instance["node_coord"])
 
     return instance
-
-
-def _identity(x):
-    return x

--- a/cvrplib/parse/parse_vrplib.py
+++ b/cvrplib/parse/parse_vrplib.py
@@ -11,7 +11,7 @@ Instance = Dict[str, Any]
 Lines = List[str]
 
 
-def parse_vrplib(text: str, distance_rounding=None) -> Instance:
+def parse_vrplib(text: str) -> Instance:
     """
     Parses the instance text. An instance consists of two main parts:
     - Problem specifications (name, dimension, edge_weight_type, ...)
@@ -21,8 +21,6 @@ def parse_vrplib(text: str, distance_rounding=None) -> Instance:
     ----------
     text
         The instance text.
-    distance_rounding
-        An optional function for custom distance rounding.
 
     Returns
     -------
@@ -69,7 +67,7 @@ def parse_vrplib(text: str, distance_rounding=None) -> Instance:
 
     # We post-process distances (e.g., compute Euclidean distances from coords,
     # or create a full matrix from an upper-triangular one).
-    distances = parse_distances(instance, distance_rounding)
+    distances = parse_distances(instance)
     instance.update(distances if distances else {})
 
     return instance

--- a/cvrplib/parse/parse_vrplib.py
+++ b/cvrplib/parse/parse_vrplib.py
@@ -24,7 +24,7 @@ def parse_vrplib(text: str) -> Instance:
 
     Returns
     -------
-    A dictionary containing the instance data.
+    The instance data as dictionary.
     """
     instance: Instance = {}
     sections = defaultdict(list)  # Store and parse section data later
@@ -61,8 +61,10 @@ def parse_vrplib(text: str) -> Instance:
             instance[section_name] = section_data
         else:
             section_data = np.array(section_data)
+
             if section_data.ndim > 1 and section_data.shape[-1] == 1:
                 section_data = section_data.squeeze(-1)
+
             instance[section_name] = section_data
 
     # We post-process distances (e.g., compute Euclidean distances from coords,

--- a/cvrplib/parse/parse_vrplib.py
+++ b/cvrplib/parse/parse_vrplib.py
@@ -61,7 +61,7 @@ def parse_vrplib(text: str) -> Instance:
         instance[name] = data
 
     # Post-process edge weights (e.g., compute Euclidean distances from
-    # node coords, or create a full matrix from an upper-triangular one).
+    # node coords, or create a full distance matrix from a triangular one).
     instance["edge_weight"] = parse_distances(instance)
 
     return instance

--- a/cvrplib/read/read_instance.py
+++ b/cvrplib/read/read_instance.py
@@ -1,7 +1,7 @@
 from cvrplib.parse import parse_solomon, parse_vrplib
 
 
-def read_instance(path, style="vrplib", distance_rounding=None):
+def read_instance(path, style="vrplib"):
     """
     Reads the instance from the passed-in file path.
 
@@ -11,9 +11,6 @@ def read_instance(path, style="vrplib", distance_rounding=None):
         The path to the instance file.
     style
         The instance format style, one of ['vrplib', 'solomon'].
-    distance_rounding
-        The rouding function to round distances. The default is to use the
-        specifications of the instance file.
 
     Returns
     -------
@@ -21,7 +18,7 @@ def read_instance(path, style="vrplib", distance_rounding=None):
     """
     with open(path, "r") as fi:
         if style == "vrplib":
-            return parse_vrplib(fi.read(), distance_rounding=distance_rounding)
+            return parse_vrplib(fi.read())
         elif style == "solomon":
             return parse_solomon(fi.read())
 

--- a/cvrplib/write/write_instance.py
+++ b/cvrplib/write/write_instance.py
@@ -25,8 +25,7 @@ def write_instance(path: str, instance: Dict[str, Any]):
             if isinstance(v, (np.ndarray, list)):
                 write_section(fi, k.upper(), v)
             else:
-                fi.write(f"{k.upper()} : {v}")
-                fi.write("\n")
+                fi.write(f"{k.upper()} : {v}" + "\n")
 
         fi.write("EOF\n")
 
@@ -35,8 +34,8 @@ def write_section(fi, name: str, data: Iterable):
     """
     Writes a data section to file.
 
-    A data section starts with the section name in all uppercase. It is then
-    followed by row entries consisting of one or multiple values.
+    A data section starts with the section name in all uppercase, followed by
+    row entries consisting of one or multiple values.
     """
     if name == "EDGE_WEIGHT":
         write_edge_weight_section(fi, data)

--- a/tests/read/test_distances.py
+++ b/tests/read/test_distances.py
@@ -12,9 +12,7 @@ def test_solution_cost(case):
     Tests if the proviced cost of the solution is the same as the cost
     calculated directly from the instance distances.
     """
-    instance = read_instance(
-        case.instance_path, distance_rounding=case.round_func
-    )
+    instance = read_instance(case.instance_path)
     solution = read_solution(case.solution_path)
 
     # Manually compute the distance from the instance and solution

--- a/tests/read/test_distances.py
+++ b/tests/read/test_distances.py
@@ -16,7 +16,7 @@ def test_solution_cost(case):
     solution = read_solution(case.solution_path)
 
     # Manually compute the distance from the instance and solution
-    dist = instance["distance"]
+    dist = instance["edge_weight"]
     cost = 0
 
     for route in solution["routes"]:


### PR DESCRIPTION
This PR:
- [x] Removes the `distance_rounding` argument to reading/parsing instance functions.
- [x] By default, if the edge weights are unspecified, computes the distance matrix using Euclidean distances.
- [x] Check if we really need flattened in distance parsing.